### PR TITLE
Trim trailing whitespace

### DIFF
--- a/#Rscript2.bat
+++ b/#Rscript2.bat
@@ -1,29 +1,29 @@
 
-@Echo OFF 
+@Echo OFF
 setlocal
-:: 
+::
 :: License: GPL 2.0
 :: (c) 2013 GKX Associates Inc.
 ::
 :: INSTALLATION INSTRUCTIONS:
 :: Modify the definitions of R_HOME and R_ARCH as needed
-:: (To get the value of R_HOME go into R and issue this command: 
+:: (To get the value of R_HOME go into R and issue this command:
 ::        normalizePath(R.home())
 :: and use its output as the value here.  If you upgrade R to another
-:: version R_HOME will need to be changed. For most users R_ARCH can 
+:: version R_HOME will need to be changed. For most users R_ARCH can
 :: be left as set but if you have a 32 bit system then comment out the
 :: line setting R_ARCH and uncomment the prior line.)
 ::
 :: RUN INSTRUCTIONS:
 :: Create an R script whose first line is:
 ::  #Rscript2.bat %0 %*
-:: and give it a .bat extesion.  If it is called test.bat then call it 
+:: and give it a .bat extesion.  If it is called test.bat then call it
 :: like this (adding arguments if any):
-::  test.bat 
+::  test.bat
 
 set R_HOME=C:\Program Files\R\R-3.0.2
 
-:: 32 or 64 bit version of R.  
+:: 32 or 64 bit version of R.
 :: (If you wish to use both versions of R make two versions of this file.)
 :: set R_ARCH=i386
 

--- a/ANNOUNCE
+++ b/ANNOUNCE
@@ -1,21 +1,21 @@
-A new version of the Windows batchfiles is available.  
+A new version of the Windows batchfiles is available.
 
 CHANGES
 
-The key change is the new R.bat utility.  R.bat has a new interface and 
+The key change is the new R.bat utility.  R.bat has a new interface and
 extended functionality covering many of the other prior utilities.  (These
 older utilities are no longer needed and have been removed.)
 
 Unlike R.bat which requires no configuration the new Rpathset.bat utility is
 configured by manually changing the Windows batch SET statements in it.  The
-main advantage is just that it is very simple internally which may be 
+main advantage is just that it is very simple internally which may be
 advantageous in some situations involving customization.
 
 A new pdf document accompanies the utilties providing more detail.
 
 OVERVIEW
 
-These are self contained independent no-install Windows batch, javascript and 
+These are self contained independent no-install Windows batch, javascript and
 .hta files. Just place any that you wish to use on your Windows PATH.
 
 R.bat
@@ -28,7 +28,7 @@ line do this:
    R gui
 
 R.bat locates R, MiKTeX and Rtools using the registry or heuristics and then
-runs the subcommand indicated by the first argument.  
+runs the subcommand indicated by the first argument.
 
 In addition to the gui subcommand, the following subcommands are available: cd,
 cmd, dir, gui, help, ls, path, R, script, show, SetReg, tools, touch.
@@ -48,7 +48,7 @@ R show -- show R_ variable values used (R_ROOT, R_HOME, R_VER, R_ARCH, etc.)
 R path -- temporarily add R, MiKTeX and Rtools to the Windows path
 R tools -- similar but only add MiKTeX and Rtools to the Windows path
 
-Except for R touch (which updates the date on your R_HOME directory) and 
+Except for R touch (which updates the date on your R_HOME directory) and
 R SetReg (which calls RSetReg.exe to update the registry with your R version),
 R.bat makes no permanent changes to your system.
 
@@ -56,16 +56,16 @@ Rpathset.bat
 
 Rpathset.bat temporarily sets the Windows path to R, Rtools and MiKTeX
 based on SET statements that the user can configure manually.  It is an
-alternative to R.bat that lacks R.bat's "no configuration" nature but may be 
+alternative to R.bat that lacks R.bat's "no configuration" nature but may be
 preferred in some situations due to its internal simplicity.
 
-Also Rpathset.bat is more likely to work on systems that have not been 
-tested given its simplicity.  (The utilities were tested on 32 bit Windows 
+Also Rpathset.bat is more likely to work on systems that have not been
+tested given its simplicity.  (The utilities were tested on 32 bit Windows
 Vista and 64 bit Windows 8 systems.)
 
 Other
 
-Other commands which continue to be available are copydir.bat, movedir.bat, 
+Other commands which continue to be available are copydir.bat, movedir.bat,
 el.js, clip2r.js and find-miktex.hta .  These copy and move R libraries,
 run a command in elevated mode (i.e. as Administrator), copy the clipboard to
 a running R instance and find MiKTeX.

--- a/NEWS
+++ b/NEWS
@@ -10,7 +10,7 @@ Changes in version 0.7-1
 
 Changes in version 0.7-0
 
-  o R.bat reworked. It now has a  with different interface and many prior 
+  o R.bat reworked. It now has a  with different interface and many prior
     batch files have been incorporated into it and removed
 
   o new Rpathset.bat
@@ -33,7 +33,7 @@ Changes in version 0.6-5
 
 		%ProgramFiles%\MySQL\*
 
-    This allows one to install and run RMySQL without setting any environment 
+    This allows one to install and run RMySQL without setting any environment
     variables.  (Note that MySQL should be installed from the mysql site.
     xampp and wamp do not include the header files needed by RMySQL.)
 
@@ -71,7 +71,7 @@ Changes in version 0.5-0
     or higher.
 
   o new command find-miktex.hta can be run without arguments from the
-    Windows command line or double clicked from Windows Explorer 
+    Windows command line or double clicked from Windows Explorer
     to show path to the MiKTeX bin directory.
 
   o Rversions.hta now also changes the .RData association and has
@@ -90,14 +90,14 @@ Changes in version 0.5-0
 
 Changes in version 0.4-3
 
-  o Sweave.bat and Stangle.bat were not automatically finding MiKTeX.  
+  o Sweave.bat and Stangle.bat were not automatically finding MiKTeX.
     Fixed.
 
 Changes in version 0.4-2
 
   o can optionally work off initialization files in place of registry.
-    Place rbatchfilesrc.bat in current directory or %userprofile% (so 
-    different directories can work off different versions of R, say) 
+    Place rbatchfilesrc.bat in current directory or %userprofile% (so
+    different directories can work off different versions of R, say)
     or same directory as the other batchfiles and it will run it first.
     Typically rbatchfiles.bat would constain these two lines or similar:
 		set R_HOME=C:\Program Files\R\R-2.7.0
@@ -110,13 +110,13 @@ Changes in version 0.4-1
   o it is no longer necessary to set any paths to build R packages
     provided Rtools 2.7 or later is used.  Rcmd.bat and the other
     scripts automatically find Rtools from the registry (including perl)
-    and if MikTeX is at %ProgramFiles%\MiKTeX* or %SystemDrive%:\MiKTex  
-    then it will find MiKTeX too.  New optional environment variables 
+    and if MikTeX is at %ProgramFiles%\MiKTeX* or %SystemDrive%:\MiKTex
+    then it will find MiKTeX too.  New optional environment variables
     R_TOOLS and R_MIKTEX are available to force specified paths to be used.
 
   o new Rtools.bat command that sets the path for the current cmd instance
     to the one that R*.bat files use internally.  That is, rtools/bin,
-    rtools/perl/bin, rtools/MinGW/bin and MiKTeX .../miktex/bin are added 
+    rtools/perl/bin, rtools/MinGW/bin and MiKTeX .../miktex/bin are added
     to the path.  This is not needed to run or install R programs but only
     if you want to access the rtools for other purposes.
 
@@ -162,7 +162,7 @@ Changes in version 0.4-0
     by Dieter Menne.
 
 Changes in version 0.3-2
- 
+
   o sweave.bat now uses Rterm.bat rather than Rcmd.bat which makes it usable
     with a basic R installation (i.e. sh.exe not needed).  Previously it
     required Rcmd.bat but now it requires Rterm.bat instead.
@@ -173,7 +173,7 @@ Changes in Version 0.3-1
 
   o new find-miktex.bat which lists the mixktex folders from the registry
 
-  o new Rscript.bat which allows one to use the Rscript facility in 
+  o new Rscript.bat which allows one to use the Rscript facility in
     R 2.5.0 and later without changing pathnames.  Just place Rscript.bat
     in any existing path and it will automatically find the
     current version of R from the registry and run the Rscript.exe that
@@ -182,24 +182,24 @@ Changes in Version 0.3-1
   o runR.bat.  If you have an R script such as myfile.R then you can create
     a batch script for it by copying runR.bat to myfile.bat.  Then when you
     issue the command myfile or myfile.bat it will run the R script in
-    myfile.R .  Just place myfile.bat and myfile.R anywhere in your path.  
+    myfile.R .  Just place myfile.bat and myfile.R anywhere in your path.
     This uses Rscript.bat .
 
   o #Rscript.  If you have an Rscript called myfile.R, say, then if you
-    copy the script to myfile.bat and place 
-       #Rscript %0 %*  
+    copy the script to myfile.bat and place
+       #Rscript %0 %*
     as the first line with the remainder being the R commands then issuing
     the command myfile or myfile.bat will run the R script.  The advantage
     over the runR.bat method is that there is only one file, myfile.bat.
-    You don't need myfile.R anymore.  The disadvantage is that it will 
-    echo the #Rscript line to stdout.  This will be fixed if and when 
-    Rscript ever gets the perl/python/ruby -x flag.  (The runR approach will 
-    not echo additional lines but does require two files.)  
+    You don't need myfile.R anymore.  The disadvantage is that it will
+    echo the #Rscript line to stdout.  This will be fixed if and when
+    Rscript ever gets the perl/python/ruby -x flag.  (The runR approach will
+    not echo additional lines but does require two files.)
 
   o new Rtidy.bat is a sample Rscript that uses the #Rscript facility
     based on George Georgalis' UNIX code
 
-  o withgs.bat now checks for latest ghostscript version.  (Previously 
+  o withgs.bat now checks for latest ghostscript version.  (Previously
     version was hard coded and it only worked for that version.)
 
 Changes in Version 0.3-0
@@ -211,13 +211,13 @@ Changes in Version 0.3-0
 
   o new --tex, --pdf, --nobck.pdf switches are available on sweave.  Also
     expanded help when entering sweave without args.
-    
+
 Changes in Version 0.2-9
 
   o updated README and other documentation files and inline documentation
 
   o added sweave.bat
- 
+
   o new google code home page and svn repository
     http://code.google.com/p/batchfiles/
 
@@ -244,7 +244,7 @@ Changes in Version 0.2-6
   o Rrefresh.bat has been removed (after having been deprecated in
     in previous versions of batchfiles).
 
-  o tested movedir.bat by using it to upgrade R-2.2.0pat to R-2.2.1.  
+  o tested movedir.bat by using it to upgrade R-2.2.0pat to R-2.2.1.
     See instructions in README.
 
 Changes in Version 0.2-5
@@ -261,27 +261,27 @@ Changes in Version 0.2-3
     R to another.  (This is a temporary solution until R provides
     facilities for upgrading the libraries, expected in R 2.3.0 .)
     See README for usage.
-    
+
   o eliminated all code associated with reading and manipulation of
     R_ENVIRON, R_PROFILE and R_LIBS simplifying the batch files.  Use
     copydir.bat instead.
 
-  o Rversions.hta is a javascript GUI version of Rversions.bat 
+  o Rversions.hta is a javascript GUI version of Rversions.bat
 
 Changes in Version 0.2-2
 
   o added jgr.bat which starts up the JGR GUI.
 
-  o added Rversions.bat which can list the directories of all R versions 
+  o added Rversions.bat which can list the directories of all R versions
     available and can set one to become the current R version.
 
-  o all batch scripts which used the environment variable name Rrw now 
+  o all batch scripts which used the environment variable name Rrw now
     use the environment variable name R_HOME instead.
 
-  o Rcmd.bat, Rgui.bat, R.bat, jgr.bat files will now read R_ENVIRON, 
+  o Rcmd.bat, Rgui.bat, R.bat, jgr.bat files will now read R_ENVIRON,
     if present, and set the R_LIBS definition in it, if present (unless
     R_LIBS is already defined as an environment variable).  All R_ENVIRON
-    file syntax accepted by R is supported including comments (#), 
+    file syntax accepted by R is supported including comments (#),
     var=value, var=${foo-bar} and recursions, var=${A-${B-C}}.
 
   o makepkg.bat internals were simplified due to previous point.
@@ -290,7 +290,7 @@ Changes in Version 0.2-2
 
   o updated THANKS.
 
-  o updated README.  More introductory information.  Also instructions 
+  o updated README.  More introductory information.  Also instructions
     for Rgui shortcut will disable screen flash on startup. Corrections.
 
 Changes in Version 0.2-1
@@ -300,18 +300,18 @@ Changes in Version 0.2-1
 Changes in Version 0.2-0
 
   o can now support configurations without *.site files (as well as
-    configurations with *.site files) thereby reducing the minimum 
-    configuration even further.  
+    configurations with *.site files) thereby reducing the minimum
+    configuration even further.
 
   o Rcmd.bat, Rgui.bat and R.bat now temporarily set R_ENVIRON,
-    R_PROFILE and R_LIBS as needed so that it is no longer necessary to 
+    R_PROFILE and R_LIBS as needed so that it is no longer necessary to
     copy the *.site files into the etc directory eliminating all
     reconfiguration when upgrading to a new version of R (except for
     refreshing MiKTeX).
 
   o new command miktex-refresh.bat is used to refresh MiKTeX after a
     new version of R is installed. Previously this was done in
-    Rrefresh.bat which is now deprecated.  Rrefresh.bat is no longer 
+    Rrefresh.bat which is now deprecated.  Rrefresh.bat is no longer
     needed (unless you want each R version to have its own *.site files).
 
   o new NEWS, WISHLIST and RESOURCES files.

--- a/R.bat
+++ b/R.bat
@@ -1,6 +1,6 @@
-@Echo OFF 
+@Echo OFF
 
-:: Software and documentation is (c) 2013 GKX Associates Inc. and 
+:: Software and documentation is (c) 2013 GKX Associates Inc. and
 :: licensed under [GPL 2.0](http://www.gnu.org/licenses/gpl-2.0.html).
 
 :: Help is at bottom of script or just run script with single argument: help
@@ -19,7 +19,7 @@
 if not defined R_REGISTRY set R_REGISTRY=1
 set CYGWIN=nodosfilewarning
 
-SetLocal EnableExtensions EnableDelayedExpansion 
+SetLocal EnableExtensions EnableDelayedExpansion
 
 ::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
 :: R_CMD
@@ -62,11 +62,11 @@ rem echo R_CMD:%R_CMD% args=[%args%]
 :::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
 :: 1. If .\Rgui.exe exist use implied R_PATH and skip remaining points.
 :: 2. If .\{x64,i386}\Rgui.exe or .\bin\{x64,i386}\Rgui.exe exists use implied R_HOME.
-:: 3. if R_HOME defined then derive any of R_ROOT and R_VER that 
+:: 3. if R_HOME defined then derive any of R_ROOT and R_VER that
 ::    are not already defined.
 :: 4. if R_PATH defined then derive any of R_ROOT, R_HOME, R_VER and R_ARCH that
 ::    are not already defined.
-:: 4a. If R_REGISTRY=1 and R found in registry derive any of R_HOME, R_ROOT and 
+:: 4a. If R_REGISTRY=1 and R found in registry derive any of R_HOME, R_ROOT and
 ::     R_VER that are not already defined.
 :: 5. If R_ROOT not defined try %ProgramFiles%\R\*, %ProgramFiles(x86)%\R\*
 ::    and then %SystemRoot%\R else error
@@ -149,7 +149,7 @@ if defined R_HOME (
     )
 )
 
-	
+
 :: 5
 
 if defined R_ROOT goto:R_ROOT_end
@@ -385,10 +385,10 @@ goto:eof
 ver | findstr XP >NUL
 if not errorlevel 1 goto:Rtouch_next
 if not exist "%ProgramFiles%\R" goto:Rtouch_next
-reg query "HKU\S-1-5-19" >NUL 2>&1 && ( goto Rtouch_next ) || ( 
+reg query "HKU\S-1-5-19" >NUL 2>&1 && ( goto Rtouch_next ) || (
         echo Please run this as Administator.
         goto :eof
-) 
+)
 :Rtouch_next
 
 if not defined R_HOME set R_HOME=%R_ROOT%\%R_VER%
@@ -401,7 +401,7 @@ goto:eof
 
 
 :::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
-:: set path 
+:: set path
 :::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
 :Rpath
 endlocal & PATH %PATH%;%R_PATH%
@@ -450,15 +450,15 @@ goto:eof
 :: Extract text from file:
 ::   %1 = input string that starts text
 ::   %2 = input file
-::   final = output variable holding text from and including %1 until 
+::   final = output variable holding text from and including %1 until
 ::    binary data encountered
 ::
-:: Needs: SetLocal EnableExtensions EnableDelayedExpansion 
+:: Needs: SetLocal EnableExtensions EnableDelayedExpansion
 ::
-:: Example:  
+:: Example:
 ::      call :extract_string {app} C:\Rtools\unins000.dat
 ::      echo %final%
-::   where {app} is the string that starts extraction and 
+::   where {app} is the string that starts extraction and
 ::         C:\Rtoolsiunins000.dat is the file
 ::
 :: Based on code by Frank Westlake, https://github.com/FrankWestlake
@@ -467,61 +467,61 @@ goto:eof
 
    :extract_string
 
-   SetLocal EnableExtensions EnableDelayedExpansion 
+   SetLocal EnableExtensions EnableDelayedExpansion
 
-   Set "string=%1" 
+   Set "string=%1"
    Set "file=%2"
 
-   For /F "delims=" %%a in ( 
-       'findstr /C:"%string%" "%file%"^|MORE' 
-     ) Do ( 
-     Set "$=%%~a" 
-     If /I "!$:~0,5!" EQU "%string%" ( 
-       Set $=!$:;=" "! 
-       For %%b in ("!$!") Do ( 
-         Set "#=%%~b" 
-         If "!#:~0,5!" EQU "%string%" ( 
+   For /F "delims=" %%a in (
+       'findstr /C:"%string%" "%file%"^|MORE'
+     ) Do (
+     Set "$=%%~a"
+     If /I "!$:~0,5!" EQU "%string%" (
+       Set $=!$:;=" "!
+       For %%b in ("!$!") Do (
+         Set "#=%%~b"
+         If "!#:~0,5!" EQU "%string%" (
            CALL :work "!#!"
-         ) 
-       ) 
-     ) 
-   ) 
+         )
+       )
+     )
+   )
    endlocal & set final=%final%
-   Goto :EOF 
-   :work 
+   Goto :EOF
+   :work
    set final=%final%!#!;
-   Goto :EOF 
+   Goto :EOF
 
- :::::::::::::::::::::::::::::::::::::::::::::::::::::::::::: 
-  :trimPath:<variable to trim> [segment to add] 
-  :: Eliminates redundant path segments from the variable and 
-  :: optionally adds new segmants. 
-  :: Example: CALL :trimPath:PATH 
-  :: Example: CALL :trimPath:PATH "C:\A & B" C:\a\b\c 
-  :: 
-  :: Note that only a colon separates the subroutine name and 
-  :: the name of the variable to be edited. 
+ ::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
+  :trimPath:<variable to trim> [segment to add]
+  :: Eliminates redundant path segments from the variable and
+  :: optionally adds new segmants.
+  :: Example: CALL :trimPath:PATH
+  :: Example: CALL :trimPath:PATH "C:\A & B" C:\a\b\c
+  ::
+  :: Note that only a colon separates the subroutine name and
+  :: the name of the variable to be edited.
   :: - Frank Westlake, https://github.com/FrankWestlake
-  SetLocal EnableExtensions EnableDelayedExpansion 
-  For /F "tokens=2 delims=:" %%a in ("%0") Do ( 
-    For %%a in (%* !%%a!) Do ( 
-      Set "#=%%~a" 
-      For %%b in (!new!) Do If /I "!#!" EQU "%%~b" Set "#=" 
-      If DEFINED # ( 
-        If DEFINED new (Set "new=!new!;!#!") Else ( Set "new=!#!") 
-      ) 
-    ) 
-  ) 
-  EndLocal & For /F "tokens=2 delims=:" %%a in ("%0") Do Set "%%a=%new%" 
-  Goto :EOF 
+  SetLocal EnableExtensions EnableDelayedExpansion
+  For /F "tokens=2 delims=:" %%a in ("%0") Do (
+    For %%a in (%* !%%a!) Do (
+      Set "#=%%~a"
+      For %%b in (!new!) Do If /I "!#!" EQU "%%~b" Set "#="
+      If DEFINED # (
+        If DEFINED new (Set "new=!new!;!#!") Else ( Set "new=!#!")
+      )
+    )
+  )
+  EndLocal & For /F "tokens=2 delims=:" %%a in ("%0") Do Set "%%a=%new%"
+  Goto :EOF
 
-:::::::::::::::::::::::::::::::::::::::::::::::::::::::::::: 
+::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
 
 :Rhelp
 
-echo (c) 2013 G. Grothendieck 
+echo (c) 2013 G. Grothendieck
 echo License: GPL 2.0 ( http://www.gnu.org/licenses/gpl-2.0.html )
-echo Launch script for R and associated functions.  
+echo Launch script for R and associated functions.
 echo Usage:  R.bat [subcommand] [arguments]
 echo Subcommands where (0) means takes no arguments; (A) means may need Admin priv
 echo   cd - cd to R_ROOT, typically to C:\Program Files\R (0)
@@ -555,35 +555,35 @@ echo   start set R_HOME=%ProgramFiles%\R\R-2.14.0 ^& R gui
 echo
 echo ==Customization by renaming==
 echo.
-echo If the optional first argument is missing then it uses the value of 
-echo the environment variable R_CMD or if that is not set it uses the name of 
-echo the script file as the default first argument.  The idea is one could have 
+echo If the optional first argument is missing then it uses the value of
+echo the environment variable R_CMD or if that is not set it uses the name of
+echo the script file as the default first argument.  The idea is one could have
 echo multiple versions of the script called R.bat, Rgui.bat, etc. which invoke
 echo the corresponding functionality without having to specify first argument.
 echo.
 echo ==Customization by setting environment variables at top of script==
 echo.
-echo It can be customized by setting any of R_CMD, R_HOME, R_ARCH, 
-echo R_MIKTEX_PATH, R_TOOLS after the @echo off command at the top of the 
-echo script.  R_CMD will be used as the default first argument (instead of the 
-echo script name).  
+echo It can be customized by setting any of R_CMD, R_HOME, R_ARCH,
+echo R_MIKTEX_PATH, R_TOOLS after the @echo off command at the top of the
+echo script.  R_CMD will be used as the default first argument (instead of the
+echo script name).
 echo.
 echo e.g. use the following after @echo off to force 32-bit
 echo set R_ARCH=32
 echo.
-echo e.g.  use the following after @echo off to force a particular version of 
+echo e.g.  use the following after @echo off to force a particular version of
 echo R to be used
 echo set R_HOME=%ProgramFiles%\R\R-2.14.0
 echo.
-echo e.g. use the following after @echo off to change the default command to 
+echo e.g. use the following after @echo off to change the default command to
 echo Rgui even if the script is called myRgui.bat, say:
 echo set R_CMD=Rgui
 echo.
 echo ==Installation==
-echo. 
+echo.
 echo The script is self contained so just place it anywhere on your Windows
 echo PATH.  (From the Windows cmd line the command PATH shows your current
-echo Windows path.)  You may optionally make copies of this script with names 
+echo Windows path.)  You may optionally make copies of this script with names
 echo like R.bat, Rscript.bat, Rcmd.bat so that each has a different default.
 echo.
 

--- a/RESOURCES
+++ b/RESOURCES
@@ -1,7 +1,7 @@
 GENERAL RESOURCES ON WINDOWS BATCH FILE PROGRAMMMING
 ----------------------------------------------------
 
-The Windows command line commands will bring up help information 
+The Windows command line commands will bring up help information
 that is particularly useful:
 
 	help set
@@ -18,7 +18,7 @@ Here are some links on Windows batch file programmming.
 
 	http://groups-beta.google.com/group/alt.msdos.batch.nt/msg/5a9587e871c27a75 - cmd bugs
 
-	http://groups-beta.google.com/group/alt.msdos.batch/msg/7b1d22945c89af75 - cmd help resources 
+	http://groups-beta.google.com/group/alt.msdos.batch/msg/7b1d22945c89af75 - cmd help resources
 
 	http://msdn.microsoft.com/downloads/list/webdev.asp - Windows script downloads
 
@@ -28,9 +28,9 @@ Here are some links on Windows batch file programmming.
 
 	http://www.commandline.co.uk - Ritchie Lawrence cmd line utilities
 
-	http://www.cybermesa.com/~bstewart/ - Bill Stewart’s scripting tools
+	http://www.cybermesa.com/~bstewart/ - Bill Stewartï¿½s scripting tools
 
-	http://www.fpschultze.de - FP Shcultze’s batch tricks
+	http://www.fpschultze.de - FP Shcultzeï¿½s batch tricks
 
 	http://www.microsoft.com/technet/community/columns/scripts - MS TechNet scripting
 

--- a/Rpathset.bat
+++ b/Rpathset.bat
@@ -1,10 +1,10 @@
-:: Software and documentation is (c) 2013 GKX Associates Inc. and 
+:: Software and documentation is (c) 2013 GKX Associates Inc. and
 :: licensed under [GPL 2.0](http://www.gnu.org/licenses/gpl-2.0.html).
 
 :: Purpose: setup path to use R, Rtools and other utilities from cmd line.
 ::
 :: Makes no permanent system changes.  Does not read or write registry.
-:: Temporarily prepends to PATH and sets environment variables for current 
+:: Temporarily prepends to PATH and sets environment variables for current
 :: Windows cmd line session only.
 ::
 :: Use: Run this each time you launch cmd.exe and want to use R or Rtools.
@@ -14,13 +14,13 @@
 :: Install: Modify set statements appropriately for your installation.
 :: and then place this batch script anywhre on your existing path.
 :: (The Windows commandline command PATH shows the current PATH.)
-:: 
+::
 :: In many cases no changes are needed at all in this file.
 :: R_HOME and R_ARCH are the most likely that may need to be changed.
 ::
 :: Report bugs to:
 :: ggrothendieck at gmail.com
-:: 
+::
 :: License: GPL 2.0
 
 :: Go into R and issue this command: normalizePath(R.home())
@@ -29,7 +29,7 @@
 :: R is available from: http://www.r-project.org
 set R_HOME=C:\Program Files\R\R-3.1.0
 
-:: 32 or 64 bit version of R.  
+:: 32 or 64 bit version of R.
 :: (If you wish to use both versions of R make two versions of this file.)
 :: set R_ARCH=i386
 set R_ARCH=x64
@@ -38,21 +38,21 @@ set R_ARCH=x64
 set R_PATH=%R_HOME%\bin\%R_ARCH%
 
 :: directory path where Rtools was installed.  Usually best to use default
-:: which is the one shown below.  Note that different versions of R may 
+:: which is the one shown below.  Note that different versions of R may
 :: require different versions of Rtools.
 :: Rtools is available from: http://cran.r-project.org/bin/windows/Rtools/
 set R_TOOLS=C:\Rtools
 
-:: If in future Rtools changes the required paths then modify accordingly.  
-:: To check, run the following findstr command which lists the R_TOOLS_PATH 
+:: If in future Rtools changes the required paths then modify accordingly.
+:: To check, run the following findstr command which lists the R_TOOLS_PATH
 :: (plus some garbage):
 ::   findstr {app} %R_TOOLS%\unins000.dat
 set R_TOOLS_PATH=%R_TOOLS%\bin;%R_TOOLS%\gcc-4.6.3\bin
 
 :: From within R, the R_USER directory path can be viewed like this:
 ::    cat(normalizePath('~'))
-:: It contains your personal .Rprofile, if any, and unless set otherwise 
-:: %R_USER%\R\win-library contains your personal R library of packages 
+:: It contains your personal .Rprofile, if any, and unless set otherwise
+:: %R_USER%\R\win-library contains your personal R library of packages
 :: (from CRAN and elsewhere).
 set R_USER=%userprofile%\Documents
 
@@ -74,11 +74,11 @@ set R_MIKTEX_PATH=C:\Program Files (x86)\MiKTeX 2.9\miktex\bin
 
 :: This is only needed to run JGR and Deducer.
 :: R_LIBS is the system library.
-:: If you have installed at least one package (at which point R will ask to 
+:: If you have installed at least one package (at which point R will ask to
 ::  set up a personal library -- which you should allow) then R_LIBS_USER
 ::  is similar to output of .libPaths() with first comnponent being your
-::  personal library and second compnent being library holding packages that 
-::  come with R.  
+::  personal library and second compnent being library holding packages that
+::  come with R.
 :: Be sure NOT to store the packages that you downloaded from CRAN
 ::  in the %R_HOME%\library directory.
 :: set R_LIBS=%R_USER%\R\win-library\2.15

--- a/batchfiles.md
+++ b/batchfiles.md
@@ -37,13 +37,13 @@ privileges).
 `clip2r.js` copies the current clipboard into a running R instance. It can be
 used with `vim` or other text editor.
 
-`find-miktex.hta` displays a popup window showing where it found MiKTeX. 
+`find-miktex.hta` displays a popup window showing where it found MiKTeX.
 
 ## R.bat ##
 
 ### Purpose ###
 
-The purpose of `R.bat` is to facilitiate the use of R from the Windows `cmd` 
+The purpose of `R.bat` is to facilitiate the use of R from the Windows `cmd`
 line by eliminating the need to make any system changes.  There is no need to
 modify the Windows path or to set any environment variables for standard
 configurations of R.  It will automatically locate R (and Rtools and
@@ -58,7 +58,7 @@ is stored only in the local process.
 such situations where there are minimal permissions.
 
 Like all the other utilities here, `R.bat` is a self contained no-install script
-with no dependencies so just place it anywhere on your Windows path or in the 
+with no dependencies so just place it anywhere on your Windows path or in the
 current directory.
 
 ### Typical Usage ###
@@ -75,7 +75,7 @@ This runs `Rgui.exe`.  If further arguments are specified they are passed on to
 
 	R gui --help
 
-will run: 
+will run:
 
 	Rgui.exe --help
 
@@ -83,7 +83,7 @@ will run:
 
 If the first argument is optionally one of `cd`, `cmd`, `dir`, `gui`, `help`,
 `path`, `R`, `script`, `show`, `SetReg`, `tools`, `touch` or the same except
-for upper/lower case then that argument is referred to as the subcommand.  
+for upper/lower case then that argument is referred to as the subcommand.
 
 If no subcommand is provided then the default subcommand is derived from the
 name of the script.
@@ -102,7 +102,7 @@ can be run in a similar way:
 	R cmd --help
 	R script --help
 
-(`RSetReg.exe` is another executable that comes with R for Windows. It will be 
+(`RSetReg.exe` is another executable that comes with R for Windows. It will be
 discussed later.)
 
 ### Support Subcommands ###
@@ -115,7 +115,7 @@ There are also some support commands:
 	R help
 	R show
 
-`R cd` changes directory to the `R_ROOT` directory (typically 
+`R cd` changes directory to the `R_ROOT` directory (typically
 `C:\Program Files\R`).
 
 `R dir` displays the contents of that directory in chronological order - oldest
@@ -123,7 +123,7 @@ first and most recent last.  `R ls` is the same as `R dir`.
 
 `R show` shows the values of the `R_` environment variables used by `R.bat` .
 Below is a list with typical values.  These values are determined by the script
-heuristically (or the user can set any before running `R.bat` or 
+heuristically (or the user can set any before running `R.bat` or
 `R.bat` itself can be customized by setting any of them near top of the script).
 
 	R_ARCH=x64
@@ -139,7 +139,7 @@ heuristically (or the user can set any before running `R.bat` or
 	R_VER=R-2.15.3
 
 `R_PATH`, `R_MIKTEX_PATH` and `R_TOOLS_PATH` are the paths to the directories
-holding the `R`, `MiKTeX` and `Rtools` binaries (i.e. `.exe` files).  
+holding the `R`, `MiKTeX` and `Rtools` binaries (i.e. `.exe` files).
 
 `R_CMD` indicates the subcommand or if no subcommand specified then it is
 derived from the name of the script.  For example if the script were renamed
@@ -155,18 +155,18 @@ values for these variables.
 
 ### Path Setting Subcommands ###
 
-The command 
+The command
 
 	R path
 
 adds `R_PATH`, `R_MIKTEX_PATH` and `R_TOOLS` to the Windows path for the
 current `cmd` line session.  No other `cmd` line sessions are affected and
-there are no permanent changes to the system.  Once this is run 
+there are no permanent changes to the system.  Once this is run
 the R binaries will be on the path so they can be accessed directly without
 `R.bat` within the same Windows cmd line session.
 
 This mode of operation has the advantage that startup will be slightly faster
-since  `R.bat` will not have to run each time that `R` is started. ^[On a 
+since  `R.bat` will not have to run each time that `R` is started. ^[On a
 1.9 GHz Windows 8 machine `R.bat show` runs in 0.75 seconds.]
 
 Note that if both `R.bat` and `R.exe` exist on the Windows path then the first
@@ -174,12 +174,12 @@ on the path will be called if one uses:
 
 	R ...arguments...
 
-thus one may wish to enter `R.bat` or `R.exe` rather than just `R` for clarity. 
+thus one may wish to enter `R.bat` or `R.exe` rather than just `R` for clarity.
 
 Alternately, rename `R.bat` to `Rpath.bat` in which case the command `R path`
 becomes just `Rpath` and `R` becomes unambiguous.
 
-(An alternative to `R path` is the `Rpathset.bat` utility which will be 
+(An alternative to `R path` is the `Rpathset.bat` utility which will be
 described later.)
 
 The command
@@ -218,7 +218,7 @@ like this:
 
 	cmd /c set R_VER=R-2.14.0 ^& R SetReg
 
-This requires Administrator privileges. If not already running as 
+This requires Administrator privileges. If not already running as
 Administrator a window will pop up requesting permission to proceed.
 
 If the registry is empty or `R_REGISTRY=0` then the default version is not
@@ -230,9 +230,9 @@ line session with Administrator privileges:
 	R dir
 	el cmd /c set R_VER=R-2.14.0 ^& R touch
 
-The value of `R_VER` in the above line must be one of the directories listed 
-by `R dir`.  The `el.js` command used in the above code comes with these batch 
-files and provides one way to elevate commands to have Administrator 
+The value of `R_VER` in the above line must be one of the directories listed
+by `R dir`.  The `el.js` command used in the above code comes with these batch
+files and provides one way to elevate commands to have Administrator
 privileges.
 
 Note that `R SetReg` and `R touch` make permanent changes to the system
@@ -250,10 +250,10 @@ permanent changes.
 3. If `R_HOME` defined then derive any of `R_ROOT` and `R_VER` that are not
 already defined.
 
-4. If `R_PATH` defined then derive any of `R_ROOT`, `R_HOME`, `R_VER` and 
+4. If `R_PATH` defined then derive any of `R_ROOT`, `R_HOME`, `R_VER` and
 `R_ARCH` that are not already defined.
 
-5. If `R_REGISTRY=1` and R found in registry derive any of `R_HOME`, `R_ROOT` 
+5. If `R_REGISTRY=1` and R found in registry derive any of `R_HOME`, `R_ROOT`
 and `R_VER` that are not already defined.
 
 6. If R_ROOT not defined try `%ProgramFiles%\R\*`, `%ProgramFiles(x86)%\R\*`
@@ -270,18 +270,18 @@ and `R_VER` that are not already defined.
 
 ## #Rscript.bat ##
 
-This is not a separate batch file but is yet another way to call `R.bat`.  
-Its purpose is to turn an R script into a Windows batch file.  
+This is not a separate batch file but is yet another way to call `R.bat`.
+Its purpose is to turn an R script into a Windows batch file.
 
-1.  Copy `R.bat` to a file with the name `#Rscript.bat` like this 
+1.  Copy `R.bat` to a file with the name `#Rscript.bat` like this
 (from the Windows cmd line):
 
 	copy R.bat #Rscript.bat
 
 2. Ensure that `#Rscript.bat` is on your windows path.  Then we can turn an
-R script into a `.bat` file by 
-(a) giving the R script a `.bat` extension and 
-(b) putting this line as the 
+R script into a `.bat` file by
+(a) giving the R script a `.bat` extension and
+(b) putting this line as the
 first line in the script: `#Rscript %0 %*`
 
 This makes the script both a Windows batch file and an R script at the same
@@ -311,25 +311,25 @@ simple to fix since the script itself is simple.
 If you have a 64 bit system then the only part that needs to be changed is
 changing the definition of R_HOME to point to your version of R.  If you
 have a 32 bit system then you will also have to modify the definition of
-R_ARCH on the appropriate line.  
+R_ARCH on the appropriate line.
 
 There is more information on this in the comments at the top of the script.
 
 ## Rpathset.bat ##
 
-The command 
+The command
 
 	Rpathset
 
 adds `R_PATH`, `R_MIKTEX_PATH` and `R_TOOLS` to the Windows path for the
 current `cmd` line session.  No other `cmd` line sessions are affected and
-there are no permanent changes to the system.  Once this is run 
+there are no permanent changes to the system.  Once this is run
 the R binaries will be on the path so they can be accessed directly without
-`R.bat` .   
+`R.bat` .
 
-`Rpathset` is an alternative to 
+`Rpathset` is an alternative to
 
-	R path 
+	R path
 
 but unlike `R.bat`, `Rpathset.bat` does not have any automatic heuristics.
 Instead, it requires that the user manually set the relevant variables in its
@@ -337,7 +337,7 @@ source.  Running `Rpathset.bat` then sets the path accordingly and from then on
 in the session one can access `Rgui.exe`, etc. on the path.  Although
 `Rpathset.bat` involves manual editing it does have the advantage that as a
 consequence it is very simple -- not much more than a collection of Windows
-batch set commands. This makes it easy to customize, less fragile to 
+batch set commands. This makes it easy to customize, less fragile to
 changes in the install procedures of `R` itself and is also more liklely to
 work on untested Windows configurations.
 
@@ -349,7 +349,7 @@ work on untested Windows configurations.
 where `Rgui` is now directly accessing `Rgui.exe` as `Rpathset.bat` has added
 `R_PATH` to the Windows path.
 
-The set statements are documented in the source of the `Rpathset.bat` file 
+The set statements are documented in the source of the `Rpathset.bat` file
 itself.
 
 ## movedir.bat and copydir.bat ##
@@ -362,15 +362,15 @@ assuming the default location for the user libraries:
 	cd %userprofile%\Documents\win-library
 	copydir 2.15\library 3.0\library
 
-	R.bat gui 
+	R.bat gui
 	... now enter update.packages(checkBuilt=TRUE) into R...
 
 (The `checkBuilt=TRUE` argument forces a rebuild and is normally not required
 when upgrading to another version that differs only in the minor version
 number, e.g. from 2.15.2 to 2.15.3.)
 
-`movedir.bat` and `copydir.bat` will not overwrite any existing package in the 
-target library so they are particularly safe to use.  (If you do wish to 
+`movedir.bat` and `copydir.bat` will not overwrite any existing package in the
+target library so they are particularly safe to use.  (If you do wish to
 overwrite such packages delete them from the target first using the Windows
 `del` command.)
 
@@ -392,7 +392,7 @@ with `vim` or other editor.  See the source for additional instructions.
 
 This program displays a window showing where MiKTeX was found. It uses the
 MiKTeX API. This API is not used by `R.bat` .  Instead `R.bat` just looks in
-common places.  (Using this API may be incorporated into the `R.bat` heuristic 
+common places.  (Using this API may be incorporated into the `R.bat` heuristic
 in the future.)
 
 ## make-batchfiles-pdf.bat ##

--- a/batchfiles.tex
+++ b/batchfiles.tex
@@ -275,7 +275,7 @@ do not.
 An alternative to
 
 \begin{verbatim}
-R.bat path 
+R.bat path
 \end{verbatim}
 
 is the \texttt{Rpathset.bat}. Unlike \texttt{R.bat},
@@ -300,7 +300,7 @@ default location for the user libraries:
 \begin{verbatim}
 cd %userprofile%\\Documents\\win-library
 copydir 2.15\\library 3.0\\library
-R.bat gui 
+R.bat gui
 ... now enter update.packages() into R...
 \end{verbatim}
 

--- a/clip2r.js
+++ b/clip2r.js
@@ -10,4 +10,3 @@
 var wsh = new ActiveXObject("Wscript.Shell");
 wsh.AppActivate("Rgui");
 wsh.SendKeys("% x%{w}1^{v}");
-

--- a/clip2r.js
+++ b/clip2r.js
@@ -1,9 +1,9 @@
-// (c) 2009.  Gabor Grothendieck. 
+// (c) 2009.  Gabor Grothendieck.
 // This is free software licensed under GPL.
 //
 // To use with vim place these two lines in your _vimrc file
 // To find the directory where _vimrc goes enter this in vim   :echo $HOME
-// 
+//
 //    map <F3> <C-C><ESC>:!start cmd /c clip2r.js<CR><CR>
 //    imap <F3> <ESC><C-C><ESC>:!start cmd /c clip2r.js<CR><CR>
 

--- a/copydir.bat
+++ b/copydir.bat
@@ -1,12 +1,12 @@
 @echo off
-:: Software and documentation is (c) 2013 GKX Associates Inc. and 
+:: Software and documentation is (c) 2013 GKX Associates Inc. and
 :: licensed under [GPL 2.0](http://www.gnu.org/licenses/gpl-2.0.html).
 setlocal
 if not "%2"=="" goto:run
 echo Usage: copydir fromdir todir
-echo All files/directories in fromdir that do not also exist in todir are 
+echo All files/directories in fromdir that do not also exist in todir are
 echo recurisvely copied.
-echo e.g. 
+echo e.g.
 echo      cd "%userprofile%\Documents\R\win-library"
 echo      copydir 2.14 2.15
 echo Now start up R 2.15.x and issue update.packages()

--- a/find-miktex.hta
+++ b/find-miktex.hta
@@ -5,7 +5,7 @@
 .highlight {background:#ff00ff}
 .text {color:#ff00ff}
 .both {color:white;background:black}
-</STYLE> 
+</STYLE>
 <title>find-miktex</title>
 </head>
 <body onLoad="window.resizeTo(650,250);">
@@ -25,7 +25,7 @@ while (true) {
 		i++;
 	} catch(e) {break};
 }
-	
+
 </script>
 </body>
 </html>

--- a/movedir.bat
+++ b/movedir.bat
@@ -1,12 +1,12 @@
 @echo off
-:: Software and documentation is (c) 2013 GKX Associates Inc. and 
+:: Software and documentation is (c) 2013 GKX Associates Inc. and
 :: licensed under [GPL 2.0](http://www.gnu.org/licenses/gpl-2.0.html).
 setlocal
 if not "%2"=="" goto:run
 echo Usage: copydir fromdir todir
-echo All files/directories in fromdir that do not also exist in todir are 
+echo All files/directories in fromdir that do not also exist in todir are
 echo recurisvely copied.
-echo e.g. 
+echo e.g.
 echo      cd "%userprofile%\Documents\R\win-library"
 echo      movedir 2.14 2.15
 echo Now start up R 2.15.x and issue update.packages()


### PR DESCRIPTION
I'm upstreaming equivalent changes that were made in the copy the GRASS GIS project uses. Some changes were made here: https://github.com/OSGeo/grass/pull/4790

This PR simply trims trailing whitespaces. It was made before introducing an .editorconfig to the repo.