### PR TITLE
Fix various typos in scripts and documentation

### DIFF
--- a/#Rscript2.bat
+++ b/#Rscript2.bat
@@ -17,7 +17,7 @@ setlocal
 :: RUN INSTRUCTIONS:
 :: Create an R script whose first line is:
 ::  #Rscript2.bat %0 %*
-:: and give it a .bat extesion.  If it is called test.bat then call it 
+:: and give it a .bat extension.  If it is called test.bat then call it 
 :: like this (adding arguments if any):
 ::  test.bat 
 

--- a/ANNOUNCE
+++ b/ANNOUNCE
@@ -6,16 +6,16 @@ The key change is the new R.bat utility.  R.bat has a new interface and
 extended functionality covering many of the other prior utilities.  (These
 older utilities are no longer needed and have been removed.)
 
-Unlike R.bat which requires no configuration the new Rpathset.bat utility is
+Unlike R.bat which requires no configuration, the new Rpathset.bat utility is
 configured by manually changing the Windows batch SET statements in it.  The
 main advantage is just that it is very simple internally which may be 
 advantageous in some situations involving customization.
 
-A new pdf document accompanies the utilties providing more detail.
+A new pdf document accompanies the utilities providing more detail.
 
 OVERVIEW
 
-These are self contained independent no-install Windows batch, javascript and 
+These are self-contained independent no-install Windows batch, JavaScript and 
 .hta files. Just place any that you wish to use on your Windows PATH.
 
 R.bat
@@ -60,14 +60,14 @@ alternative to R.bat that lacks R.bat's "no configuration" nature but may be
 preferred in some situations due to its internal simplicity.
 
 Also Rpathset.bat is more likely to work on systems that have not been 
-tested given its simplicity.  (The utilities were tested on 32 bit Windows 
-Vista and 64 bit Windows 8 systems.)
+tested given its simplicity.  (The utilities were tested on 32-bit Windows 
+Vista and 64-bit Windows 8 systems.)
 
 Other
 
 Other commands which continue to be available are copydir.bat, movedir.bat, 
 el.js, clip2r.js and find-miktex.hta .  These copy and move R libraries,
-run a command in elevated mode (i.e. as Administrator), copy the clipboard to
+run a command in elevated mode (i.e., as Administrator), copy the clipboard to
 a running R instance and find MiKTeX.
 
 More Info

--- a/NEWS
+++ b/NEWS
@@ -10,13 +10,13 @@ Changes in version 0.7-1
 
 Changes in version 0.7-0
 
-  o R.bat reworked. It now has a  with different interface and many prior 
+  o R.bat reworked. It now has a different interface and many prior 
     batch files have been incorporated into it and removed
 
   o new Rpathset.bat
 
   o new documentation: batchfiles.md (and batchfiles.pdf produced from it
-    using make-batchfiles.pdf.bat
+    using make-batchfiles.pdf.bat)
 
 Change in version 0.6-7
 
@@ -72,7 +72,7 @@ Changes in version 0.5-0
 
   o new command find-miktex.hta can be run without arguments from the
     Windows command line or double clicked from Windows Explorer 
-    to show path to the MiKTeX bin directory.
+    to show the path to the MiKTeX bin directory.
 
   o Rversions.hta now also changes the .RData association and has
     been verified to work on both XP and Vista.
@@ -96,10 +96,10 @@ Changes in version 0.4-3
 Changes in version 0.4-2
 
   o can optionally work off initialization files in place of registry.
-    Place rbatchfilesrc.bat in current directory or %userprofile% (so 
+    Place rbatchfilesrc.bat in the current directory or %userprofile% (so 
     different directories can work off different versions of R, say) 
     or same directory as the other batchfiles and it will run it first.
-    Typically rbatchfiles.bat would constain these two lines or similar:
+    Typically rbatchfiles.bat would contain these two lines or similar:
 		set R_HOME=C:\Program Files\R\R-2.7.0
 		set R_TOOLS=C:\Rtools
 
@@ -133,7 +133,7 @@ Changes in version 0.4-0
     which is a directory and starts up there
 
   o the dependency of sweave.bat on Rterm.bat was eliminated so all
-    batch and javascript programs in this collection are now independent
+    batch and JavaScript programs in this collection are now independent
     of each other and have no dependencies aside form R.  (The perl
     program, toggleDoc.pl, is does depend on perl and toggleDoc.js.)
 
@@ -164,14 +164,14 @@ Changes in version 0.4-0
 Changes in version 0.3-2
  
   o sweave.bat now uses Rterm.bat rather than Rcmd.bat which makes it usable
-    with a basic R installation (i.e. sh.exe not needed).  Previously it
+    with a basic R installation (i.e., sh.exe not needed).  Previously it
     required Rcmd.bat but now it requires Rterm.bat instead.
 
   o added Rterm.bat (just a copy of Rcmd.bat)
 
 Changes in Version 0.3-1
 
-  o new find-miktex.bat which lists the mixktex folders from the registry
+  o new find-miktex.bat which lists the miktex folders from the registry
 
   o new Rscript.bat which allows one to use the Rscript facility in 
     R 2.5.0 and later without changing pathnames.  Just place Rscript.bat
@@ -218,7 +218,7 @@ Changes in Version 0.2-9
 
   o added sweave.bat
  
-  o new google code home page and svn repository
+  o new Google code home page and svn repository
     http://code.google.com/p/batchfiles/
 
 Changes in Version 0.2-8
@@ -242,7 +242,7 @@ Changes in Version 0.2-6
   o Rversions.hta - fix for path names with spaces
 
   o Rrefresh.bat has been removed (after having been deprecated in
-    in previous versions of batchfiles).
+    previous versions of batchfiles).
 
   o tested movedir.bat by using it to upgrade R-2.2.0pat to R-2.2.1.  
     See instructions in README.
@@ -266,7 +266,7 @@ Changes in Version 0.2-3
     R_ENVIRON, R_PROFILE and R_LIBS simplifying the batch files.  Use
     copydir.bat instead.
 
-  o Rversions.hta is a javascript GUI version of Rversions.bat 
+  o Rversions.hta is a JavaScript GUI version of Rversions.bat 
 
 Changes in Version 0.2-2
 

--- a/R.bat
+++ b/R.bat
@@ -277,7 +277,7 @@ if not defined R_MIKTEX_PATH for /f "delims=" %%a in (
 
 if not defined R_MIKTEX_PATH for /f "delims=" %%a in (
     'dir /b /on %SystemDrive%:\miktex* 2^>NUL'
-) do set R_MIKTEX_PATH=%SystemDrive%:\%%a\mixtex\bin
+) do set R_MIKTEX_PATH=%SystemDrive%:\%%a\miktex\bin
 
 :miktex_end
 
@@ -386,7 +386,7 @@ ver | findstr XP >NUL
 if not errorlevel 1 goto:Rtouch_next
 if not exist "%ProgramFiles%\R" goto:Rtouch_next
 reg query "HKU\S-1-5-19" >NUL 2>&1 && ( goto Rtouch_next ) || ( 
-        echo Please run this as Administator.
+        echo Please run this as Administrator.
         goto :eof
 ) 
 :Rtouch_next
@@ -495,7 +495,7 @@ goto:eof
  :::::::::::::::::::::::::::::::::::::::::::::::::::::::::::: 
   :trimPath:<variable to trim> [segment to add] 
   :: Eliminates redundant path segments from the variable and 
-  :: optionally adds new segmants. 
+  :: optionally adds new segments. 
   :: Example: CALL :trimPath:PATH 
   :: Example: CALL :trimPath:PATH "C:\A & B" C:\a\b\c 
   :: 
@@ -555,35 +555,35 @@ echo   start set R_HOME=%ProgramFiles%\R\R-2.14.0 ^& R gui
 echo
 echo ==Customization by renaming==
 echo.
-echo If the optional first argument is missing then it uses the value of 
-echo the environment variable R_CMD or if that is not set it uses the name of 
-echo the script file as the default first argument.  The idea is one could have 
+echo If the optional first argument is missing, then it uses the value of 
+echo the environment variable R_CMD or if that is not set, it uses the name of 
+echo the script file as the default first argument. The idea is one could have 
 echo multiple versions of the script called R.bat, Rgui.bat, etc. which invoke
 echo the corresponding functionality without having to specify first argument.
 echo.
-echo ==Customization by setting environment variables at top of script==
+echo ==Customization by setting environment variables at the top of script==
 echo.
 echo It can be customized by setting any of R_CMD, R_HOME, R_ARCH, 
 echo R_MIKTEX_PATH, R_TOOLS after the @echo off command at the top of the 
 echo script.  R_CMD will be used as the default first argument (instead of the 
 echo script name).  
 echo.
-echo e.g. use the following after @echo off to force 32-bit
+echo e.g., use the following after @echo off to force 32-bit
 echo set R_ARCH=32
 echo.
-echo e.g.  use the following after @echo off to force a particular version of 
+echo e.g.,  use the following after @echo off to force a particular version of 
 echo R to be used
 echo set R_HOME=%ProgramFiles%\R\R-2.14.0
 echo.
-echo e.g. use the following after @echo off to change the default command to 
+echo e.g., use the following after @echo off to change the default command to 
 echo Rgui even if the script is called myRgui.bat, say:
 echo set R_CMD=Rgui
 echo.
 echo ==Installation==
 echo. 
-echo The script is self contained so just place it anywhere on your Windows
-echo PATH.  (From the Windows cmd line the command PATH shows your current
-echo Windows path.)  You may optionally make copies of this script with names 
+echo The script is self-contained so just place it anywhere on your Windows
+echo PATH. (From the Windows cmd line the command PATH shows your current
+echo Windows path.) You may optionally make copies of this script with names 
 echo like R.bat, Rscript.bat, Rcmd.bat so that each has a different default.
 echo.
 

--- a/README.html
+++ b/README.html
@@ -4,6 +4,6 @@
 <p>
 Home Page: <A href="http://batchfiles.googlecode.com">batchfiles home page</a>.
 <p>
-Discuss: <a href="http://groups.google.com/group/sqldf">sqldf dicussion group</a> is being used for discussion of this software too.
+Discuss: <a href="http://groups.google.com/group/sqldf">sqldf discussion group</a> is being used for discussion of this software too.
 <p>
 SVN:  <a href="https://code.google.com/p/batchfiles/source/checkout">source</a>

--- a/RESOURCES
+++ b/RESOURCES
@@ -1,4 +1,4 @@
-GENERAL RESOURCES ON WINDOWS BATCH FILE PROGRAMMMING
+GENERAL RESOURCES ON WINDOWS BATCH FILE PROGRAMMING
 ----------------------------------------------------
 
 The Windows command line commands will bring up help information 
@@ -8,7 +8,7 @@ that is particularly useful:
 	help for
 	help if
 
-Here are some links on Windows batch file programmming.
+Here are some links on Windows batch file programming.
 
 	ftp://garbo.uwasa.fi/pc/link/tscmd.zip - FAQ with many idioms
 

--- a/Rpathset.bat
+++ b/Rpathset.bat
@@ -12,7 +12,7 @@
 :: where Rgui may be replaced with R, Rscript, etc.
 ::
 :: Install: Modify set statements appropriately for your installation.
-:: and then place this batch script anywhre on your existing path.
+:: and then place this batch script anywhere on your existing path.
 :: (The Windows commandline command PATH shows the current PATH.)
 :: 
 :: In many cases no changes are needed at all in this file.
@@ -76,15 +76,15 @@ set R_MIKTEX_PATH=C:\Program Files (x86)\MiKTeX 2.9\miktex\bin
 :: R_LIBS is the system library.
 :: If you have installed at least one package (at which point R will ask to 
 ::  set up a personal library -- which you should allow) then R_LIBS_USER
-::  is similar to output of .libPaths() with first comnponent being your
-::  personal library and second compnent being library holding packages that 
+::  is similar to output of .libPaths() with the first component being your
+::  personal library and second component being library holding packages that 
 ::  come with R.  
 :: Be sure NOT to store the packages that you downloaded from CRAN
 ::  in the %R_HOME%\library directory.
 :: set R_LIBS=%R_USER%\R\win-library\2.15
 :: set R_LIBS_USER=%R_LIBS%;%R_HOME%\library
 
-:: adds directory to path for the remainder of current cmd line session
+:: adds directory to path for the remainder of the current cmd line session
 path %R_TOOLS_PATH%;%R_MIKTEX_PATH%;%PATH%;%R_PATH%
 
 :: if there are no arguments we are done; else run the argument

--- a/THANKS
+++ b/THANKS
@@ -1,14 +1,14 @@
 
 Thanks to the following for code:
 
-  Nicholas Hirschey <<Nicholas.Hirschey@phd.mccombs.utexas.edu>
+  Nicholas Hirschey <Nicholas.Hirschey@phd.mccombs.utexas.edu>
   Dieter Menne <dieter.menne@menne-biomed.de>
   Erich Neuwirth <erich.neuwirth@univie.ac.at>
   Frank Westlake
 
 Thanks to the following for locating bugs:
 
-  Nicholas Hirschey <<Nicholas.Hirschey@phd.mccombs.utexas.edu>
+  Nicholas Hirschey <Nicholas.Hirschey@phd.mccombs.utexas.edu>
   Xiaohua Dai <ecoinformatics@gmail.com>
 
 Thanks to the following people for discussion related to R:

--- a/batchfiles.md
+++ b/batchfiles.md
@@ -6,10 +6,10 @@ Software and documentation is (c) 2013 GKX Associates Inc. and licensed under [G
 
 ## Introduction ##
 
-This document describes a number of Windows batch, javascript and `.hta` files
-that may be used in conjunction with R.  Each is self contained and independent
+This document describes a number of Windows batch, JavaScript and `.hta` files
+that may be used in conjunction with R.  Each is self-contained and independent
 of the others.  None requires installation - just place on the Windows path or
-in current directory.  ^[To display the Windows path enter `path` without
+in the current directory.  ^[To display the Windows path enter `path` without
 arguments at the Windows `cmd` line.  To display the path to the current
 directory enter `cd` without arguments at the Windows `cmd` line.]
 
@@ -31,7 +31,7 @@ Windows batch file (as described later).
 `movedir.bat` and `copydir.bat` are used for moving or copying packages from
 one library to another such as when R is upgraded to a new version.
 
-`el.js` runs its arguments in elevated mode (i.e. with Administrator
+`el.js` runs its arguments in elevated mode (i.e., with Administrator
 privileges).
 
 `clip2r.js` copies the current clipboard into a running R instance. It can be
@@ -43,7 +43,7 @@ used with `vim` or other text editor.
 
 ### Purpose ###
 
-The purpose of `R.bat` is to facilitiate the use of R from the Windows `cmd` 
+The purpose of `R.bat` is to facilitate the use of R from the Windows `cmd` 
 line by eliminating the need to make any system changes.  There is no need to
 modify the Windows path or to set any environment variables for standard
 configurations of R.  It will automatically locate R (and Rtools and
@@ -70,7 +70,7 @@ have to be written as follows: `R.bat gui`]:
 	R gui
 
 
-This runs `Rgui.exe`.  If further arguments are specified they are passed on to
+This runs `Rgui.exe`.  If further arguments are specified, they are passed on to
 `Rgui.exe`.  For example,
 
 	R gui --help
@@ -124,7 +124,7 @@ first and most recent last.  `R ls` is the same as `R dir`.
 `R show` shows the values of the `R_` environment variables used by `R.bat` .
 Below is a list with typical values.  These values are determined by the script
 heuristically (or the user can set any before running `R.bat` or 
-`R.bat` itself can be customized by setting any of them near top of the script).
+`R.bat` itself can be customized by setting any of them near the top of the script).
 
 	R_ARCH=x64
 	R_CMD=RShow
@@ -142,13 +142,13 @@ heuristically (or the user can set any before running `R.bat` or
 holding the `R`, `MiKTeX` and `Rtools` binaries (i.e. `.exe` files).  
 
 `R_CMD` indicates the subcommand or if no subcommand specified then it is
-derived from the name of the script.  For example if the script were renamed
+derived from the name of the script.  For example, if the script were renamed
 `Rgui.bat` then if no subcommand were specified it would default to `gui`.
 
 `R_ROOT` is the directory holding all the R installations. `R_HOME` is the
 directory of the particular R installation.  `R_HOME` is made up of `R_ROOT`
 and `R_VER` so that `R_VER` represents the directory that holds the particular
-R version used.  `R_ARCH` is `i386` or `x64` for 32 bit or 64 bit R
+R version used.  `R_ARCH` is `i386` or `x64` for 32 bit or 64-bit R
 respectively.  It can also be specified as `32` or `64` in which case it will
 be translated automatically.  See the `R show` output above for examples of
 values for these variables.
@@ -161,7 +161,7 @@ The command
 
 adds `R_PATH`, `R_MIKTEX_PATH` and `R_TOOLS` to the Windows path for the
 current `cmd` line session.  No other `cmd` line sessions are affected and
-there are no permanent changes to the system.  Once this is run 
+there are no permanent changes to the system.  Once this is run, 
 the R binaries will be on the path so they can be accessed directly without
 `R.bat` within the same Windows cmd line session.
 
@@ -194,7 +194,7 @@ those utilities without R.
 ### Selecting R Version ###
 
 For R installations using the standard locations and not specifying any of the
-R_ environment variables the registry will determine which version of R is used
+R_ environment variables, the registry will determine which version of R is used
 (assuming `R_REGISTRY` is not `0`).  If R is not found in the registry or if
 `R_REGISTRY` is `0` then the R
 installation in `R_ROOT` which has the most recent date will be used.
@@ -204,7 +204,7 @@ If we enter this at the `cmd` line:
 	set R_VER=R-2.14.0
 
 then for the remainder of this `cmd` line session that version will be used.
-If one wishes to use two different R versions at once we could spawn a new `cmd`
+If one wishes to use two different R versions at once, we could spawn a new `cmd`
 line session:
 
 	start
@@ -213,7 +213,7 @@ and then enter the same set command into the new window.  Now any use of R in
 the original window will use the default version whereas in the new `cmd` line
 window it will use the specified version.
 
-One can change the registry entry permanently to refer to a particlar version
+One can change the registry entry permanently to refer to a particular version
 like this:
 
 	cmd /c set R_VER=R-2.14.0 ^& R SetReg
@@ -285,7 +285,7 @@ R script into a `.bat` file by
 first line in the script: `#Rscript %0 %*`
 
 This makes the script both a Windows batch file and an R script at the same
-time. When run as a batch file it will invoke `#Rscript.bat` which in turn
+time. When run as a batch file, it will invoke `#Rscript.bat` which in turn
 will self call the script as an R script.  (It would also be possible to
 run the script directly as an R script.  In that case the #Rscript line would
 be ignored since it would be regarded as a comment by R.)
@@ -305,12 +305,12 @@ This batch file is used in exactly the same manner as #Rscript.bat .  The only
 difference is that unlike #Rscript.bat which automatically finds R with this
 script the user must edit it to indicate where R is located.  Although this
 involves an extra installation step in return the script is very simple so
-its less likely to go wrong and if something does go wrong then its relatively
+it's less likely to go wrong and if something does go wrong then it's relatively
 simple to fix since the script itself is simple.
 
-If you have a 64 bit system then the only part that needs to be changed is
+If you have a 64-bit system then the only part that needs to be changed is
 changing the definition of R_HOME to point to your version of R.  If you
-have a 32 bit system then you will also have to modify the definition of
+have a 32-bit system then you will also have to modify the definition of
 R_ARCH on the appropriate line.  
 
 There is more information on this in the comments at the top of the script.
@@ -338,7 +338,7 @@ in the session one can access `Rgui.exe`, etc. on the path.  Although
 `Rpathset.bat` involves manual editing it does have the advantage that as a
 consequence it is very simple -- not much more than a collection of Windows
 batch set commands. This makes it easy to customize, less fragile to 
-changes in the install procedures of `R` itself and is also more liklely to
+changes in the install procedures of `R` itself and is also more likely to
 work on untested Windows configurations.
 
 `Rpathset.bat` might be used like this:
@@ -377,7 +377,7 @@ overwrite such packages delete them from the target first using the Windows
 
 ## el.js ##
 
-`el.js` runs its arguments elevated (i.e. with Adminstrator privileges).  For example,
+`el.js` runs its arguments elevated (i.e. with Administrator privileges).  For example,
 
 	el R touch
 
@@ -388,7 +388,7 @@ The user will be prompted to allow elevation to proceed.
 This program writes the clipboard into the running R session.  It can be used
 with `vim` or other editor.  See the source for additional instructions.
 
-## find-mixtex.hta ##
+## find-miktex.hta ##
 
 This program displays a window showing where MiKTeX was found. It uses the
 MiKTeX API. This API is not used by `R.bat` .  Instead `R.bat` just looks in

--- a/batchfiles.tex
+++ b/batchfiles.tex
@@ -7,9 +7,9 @@ under \href{http://www.gnu.org/licenses/gpl-2.0.html}{GPL 2.0}.
 
 \subsection{Introduction}
 
-This document describes a number of Windows batch, javascript and
+This document describes a number of Windows batch, JavaScript and
 \texttt{.hta} files that may be used in conjunction with R. Each is self
-contained and independent of the others. Each requires no installation -
+-contained and independent of the others. Each requires no installation -
 just place it on the Windows path\footnote{To display the Windows path
   enter \texttt{path} at the Windows \texttt{cmd} line.}.
 
@@ -39,12 +39,12 @@ MiKTeX.
 
 \subsubsection{Purpose}
 
-The purpose of R.bat is to facilitiate the use of R from the Windows
+The purpose of R.bat is to facilitate the use of R from the Windows
 \texttt{cmd} line by eliminating the need to make any systems changes.
 There is no need to modify the Windows PATH or to set any environment
 variables for standard configurations of R. It will automatically locate
 R (and Rtools and MiKTeX if installed) and then run \texttt{R.exe},
-\texttt{Rgui.exe} or other command.
+\texttt{Rgui.exe} or other commands.
 
 It is a self contained no-install script with no dependencies so just
 place it anywhere on your Windows path.
@@ -111,7 +111,7 @@ R.bat show
 that \texttt{R.bat} uses. Here is a list with typical values. These
 values are determined by the script heuristically (or the user can set
 any before running \texttt{R.bat} or by customizing \texttt{R.bat}
-itself by setting any of them near top of the script).
+itself by setting any of them near the top of the script).
 
 \begin{verbatim}
 R_ARCH=x64
@@ -132,7 +132,7 @@ are the paths to the directories holding the \texttt{R}, \texttt{MiKTeX}
 and \texttt{Rtools} binaries.
 
 \texttt{R\_CMD} indicates the subcommand or if no subcommand specified
-then is derived from the name of the script. For example if the script
+then is derived from the name of the script. For example, if the script
 were renamed \texttt{Rgui.bat} then if no subcommand were specified it
 would default to \texttt{gui}.
 
@@ -141,7 +141,7 @@ would default to \texttt{gui}.
 \texttt{R\_HOME} is made up of \texttt{R\_ROOT} and \texttt{R\_VER} so
 that \texttt{R\_VER} represents the directory that holds the particular
 R version used. \texttt{R\_ARCH} is \texttt{i386} or \texttt{x64} for 32
-bit or 64 bit R respectively. It can also be specified as \texttt{32} or
+bit or 64-bit R respectively. It can also be specified as \texttt{32} or
 \texttt{64} in which case it will be translated automatically.
 
 \subsubsection{Path Setting Subcommands}
@@ -158,7 +158,7 @@ the Windows path for the current \texttt{cmd} line session. No other
 changes to the system. Once this is run one no longer needs R.bat in the
 current session as the R binaries such as \texttt{R.exe},
 \texttt{Rgui.exe} will be directly on the path. (An alternative to this
-is the \texttt{Rpathset.bat} utility which will be desribed later.)
+is the \texttt{Rpathset.bat} utility which will be described later.)
 
 \begin{verbatim}
 R.bat tools
@@ -171,7 +171,7 @@ you need to use those utilities without R.
 \subsubsection{Selecting R Version}
 
 For R installations using the standard locations and not specifying any
-of the R\_ environment variables the registry will determine which
+of the R\_ environment variables, the registry will determine which
 version of R is used (assuming \texttt{R\_REGISTRY} is not 0). If R is
 not found in the registry the R installation in \texttt{R\_ROOT} which
 has the most recent date will be used.
@@ -183,7 +183,7 @@ set R_VER=R-2.14.0
 \end{verbatim}
 
 and now for the remainder of this \texttt{cmd} line session that version
-will be used. If one wants to use two different R versions at once we
+will be used. If one wants to use two different R versions at once, we
 could spawn a new \texttt{cmd} line session with the new version:
 
 \begin{verbatim}
@@ -194,7 +194,7 @@ and then enter the same set command into the new window. Now any use of
 R in the original window will use the default version and in the new
 version will use the specified version.
 
-One can change the registry entry permanently to refer to a particlar
+One can change the registry entry permanently to refer to a particular
 version like this:
 
 \begin{verbatim}
@@ -283,7 +283,7 @@ is the \texttt{Rpathset.bat}. Unlike \texttt{R.bat},
 the various set commands in it. Running \texttt{Rpathset.bat} then sets
 the path accordingly and from then on in the session one can access
 Rgui.exe, etc. on the path. Although \texttt{Rpathset.bat} involves
-manual editing it does have the advantage that as a consequence it is
+manual editing, it does have the advantage that as a consequence it is
 very simple -- not much more than a collection of Windows batch set
 commands.
 
@@ -293,7 +293,7 @@ The set statements are documented in the source of the file itself.
 
 \texttt{movedir.bat} and \texttt{copydir.bat} move or copy the packages
 from one library to another. If used to transfer packages from one
-version of R to another it is recommended that the user run
+version of R to another, it is recommended that the user run
 \texttt{upgrade.packages()} in the target. For example, assuming the
 default location for the user libraries:
 
@@ -306,7 +306,7 @@ R.bat gui
 
 \subsection{el.js}
 
-\texttt{el.js} runs its arguments elevated (i.e.~with Adminstrator
+\texttt{el.js} runs its arguments elevated (i.e.,~with Administrator
 privileges).
 
 \subsection{clip2r.js}
@@ -315,7 +315,7 @@ This program writes the clipboard into the running R session. It can be
 used with vim or other editor. See the source for additional
 instructions.
 
-\subsection{find-mixtex.hta}
+\subsection{find-miktex.hta}
 
 This program displays a window showing where MiKTeX was found. It uses
 the MiKTeX API. This API is not used by \texttt{R.bat} . It may be

--- a/copydir.bat
+++ b/copydir.bat
@@ -5,15 +5,15 @@ setlocal
 if not "%2"=="" goto:run
 echo Usage: copydir fromdir todir
 echo All files/directories in fromdir that do not also exist in todir are 
-echo recurisvely copied.
-echo e.g. 
+echo recursively copied.
+echo e.g., 
 echo      cd "%userprofile%\Documents\R\win-library"
 echo      copydir 2.14 2.15
 echo Now start up R 2.15.x and issue update.packages()
 goto:eof
 :run
 :: Notes on code:
-:: on xcopy command /e copies subdir/files incl empty ones
+:: on xcopy command /e copies subdir/files including empty ones
 :: on xcopy command /i causes target to be created
 for /D  %%a in ("%~1\*") do if not exist %2\%%~na xcopy /e/i "%%a" "%~2\%%~nxa"
 endlocal

--- a/movedir.bat
+++ b/movedir.bat
@@ -5,8 +5,8 @@ setlocal
 if not "%2"=="" goto:run
 echo Usage: copydir fromdir todir
 echo All files/directories in fromdir that do not also exist in todir are 
-echo recurisvely copied.
-echo e.g. 
+echo recursively copied.
+echo e.g., 
 echo      cd "%userprofile%\Documents\R\win-library"
 echo      movedir 2.14 2.15
 echo Now start up R 2.15.x and issue update.packages()


### PR DESCRIPTION
Following #2 and #3, this PR fixes typos across the various scripts and documentation.

I cherry-picked the changes to be independent of #2 and #3. The combined, final state (of #2, #3 and this #4), would be https://github.com/echoix/batchfiles/tree/fix-typos-orig

The first of these three PRs will not conflict, the following will need to be adjusted before merging.